### PR TITLE
Upgrade to latest releases (SSL 1.0.2h / Erlang 19.0.5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ MAINTAINER Dmitry Kolesnikov <dmkolesnikov@gmail.com>
 
 ##
 ##
-ARG OTP=18.2.1
-ARG SSL=1.0.2f
+ARG OTP_VERSION=19.0.5
+ARG SSL_VERSION=1.0.2h
 
 ##
 ## install dependencies
@@ -26,58 +26,48 @@ RUN \
 
 ##
 ## install open ssl
-RUN cd /tmp && \
-   curl -L -O http://www.openssl.org/source/openssl-${SSL}.tar.gz
-RUN cd /tmp && \
-   tar -zxvf openssl-${SSL}.tar.gz
-
-RUN cd /tmp/openssl-${SSL} && \
-   ./Configure \
-      --prefix=/usr/local/ssl \
-      --openssldir=/usr/local/ssl \
+RUN set -e \
+   && mkdir -p /tmp/openssl \
+   && cd /tmp \
+   && curl -fSL -o openssl.sha256   http://www.openssl.org/source/openssl-${SSL_VERSION}.tar.gz.sha256 \
+   && curl -fSL -o openssl.tar.gz http://www.openssl.org/source/openssl-${SSL_VERSION}.tar.gz \
+   && SHA=$(printf "%s  openssl.tar.gz" `cat openssl.sha256` | sha256sum -c -); if [ "openssl.tar.gz: OK" != "${SHA}" ]; then exit 3; fi \
+   && tar -zxf openssl.tar.gz -C /tmp/openssl --strip-components=1 \
+   && cd /tmp/openssl \
+   && ./Configure \
+         --prefix=/usr/local/ssl \
+         --openssldir=/usr/local/ssl \
       linux-x86_64 \
-      shared
-      
-RUN cd /tmp/openssl-${SSL} && \
-   make && \
-   make install
+      shared \
+   && make \
+   && make install
 
-RUN rm -Rf /tmp/openssl-${SSL}*
-
+RUN cd /tmp; rm -Rf /tmp/openssl*
 
 ##
 ## download
-RUN cd /tmp && \
-   curl -L -O http://www.erlang.org/download/otp_src_${OTP}.tar.gz
-RUN cd /tmp && \
-   tar -zxvf otp_src_${OTP}.tar.gz
+RUN set -e \
+   && mkdir -p /tmp/otp_src \
+   && cd /tmp \
+   && curl -fSL -o otp_src.tar.gz https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz \
+   && tar -zxf otp_src.tar.gz -C /tmp/otp_src --strip-components=1 \
+   && cd /tmp/otp_src \
+   && ./otp_build autoconf \
+   && ./configure \
+         --prefix=/usr/local/otp_${OTP_VERSION} \
+         --enable-threads \
+         --enable-smp-support \
+         --enable-kernel-poll \
+         --enable-hipe \
+         --enable-native-libs \
+         --disable-dynamic-ssl-lib \
+         --with-ssl=/usr/local/ssl \
+   && make \
+   && make install \
+   && ln -s /usr/local/otp_${OTP_VERSION} /usr/local/otp
 
-##
-## configure
-RUN cd /tmp/otp_src_${OTP} && \
-   ./configure \
-      --prefix=/usr/local/otp_${OTP} \
-      --enable-threads \
-      --enable-smp-support \
-      --enable-kernel-poll \
-      --enable-hipe \
-      --enable-native-libs \
-      --disable-dynamic-ssl-lib \
-      --with-ssl=/usr/local/ssl 
-
-#
-#     CFLAGS="-DOPENSSL_NO_EC=1"
-
-##
-## build
-RUN cd /tmp/otp_src_${OTP} && \
-   make && \
-   make install && \
-   ln -s /usr/local/otp_${OTP} /usr/local/otp
-
-RUN rm -Rf /tmp/otp_src_${OTP}*
+RUN cd /tmp; rm -Rf /tmp/otp_src*
 
 ENV PATH $PATH:/usr/local/otp/bin
 
 EXPOSE 4369
-

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,22 @@
+## @author     Dmitry Kolesnikov, <dmkolesnikov@gmail.com>
+## @copyright  (c) 2014 Dmitry Kolesnikov. All Rights Reserved
+##
+## Generate a custom Dockerfile to build Docker images for
+## various versions of Erlang/OTP.
+
 ##
 ## container identity
 IID ?= fogfish
 APP ?= erlang
-VSN ?= 18.2.1
+ERL_VSN ?= 19.0.5
+SSL_VSN ?=  1.0.2h
 
 ##
 ## image build flags
 DFLAGS = \
    --rm=true \
-   --build-arg SSL=1.0.2f \
-   --build-arg OTP=${VSN}
+   --build-arg OTP_VERSION=${ERL_VSN} \
+   --build-arg SSL_VERSION=${SSL_VSN}
 
 ##
 ## image run flags
@@ -18,15 +25,14 @@ IFLAGS =
 ##
 ## build container
 docker: Dockerfile
-	docker build ${DFLAGS} -t ${IID}/${APP}:${VSN} - < $< 
+	docker build ${DFLAGS} -t ${IID}/${APP}:${ERL_VSN} - < $< 
 
 ##
 ## 
 run:
-	docker run -it ${IFLAGS} ${IID}/${APP}:${VSN}
+	docker run -it ${IFLAGS} ${IID}/${APP}:${ERL_VSN} erl
 
 ##
 ##
 debug:
-	docker run -it ${IFLAGS} ${IID}/${APP}:${VSN} bash
-
+	docker run -it ${IFLAGS} ${IID}/${APP}:${ERL_VSN} bash


### PR DESCRIPTION
The following changes were made, based on the erlang "official"
Debian Dockerfile released by Erlang Solutions:
- Check the SHA256 when fetching OpenSSL prior to build
- Using SSL/OTP version only when necesary
- Combined RUNs into single 'set -e' command line
